### PR TITLE
Fix json dumping to cdb (running with from_json true)

### DIFF
--- a/BNLReloadedServer/RunServer.cs
+++ b/BNLReloadedServer/RunServer.cs
@@ -28,10 +28,12 @@ if (toJson || fromJson)
         var deserializedCards = JsonSerializer.Deserialize<List<Card>>(fs.ReadToEnd(), JsonHelper.DefaultSerializerSettings);
         if (deserializedCards is not null)
         {
-            deserializedCards.RemoveAll(c => c is CardMap or CardMapData);
+            var mapsFromFolder = Databases.MapDatabase.GetMapCards();
+            var mapsFromFolderIds = new HashSet<string>(mapsFromFolder.Select(m => m.Id ?? ""));
+            deserializedCards.RemoveAll(c => c is (CardMap or CardMapData) && mapsFromFolderIds.Contains(c.Id ?? ""));
             
             // Add maps
-            foreach (var map in Databases.MapDatabase.GetMapCards())
+            foreach (var map in mapsFromFolder)
             {
                 var exists = false;
                 foreach (var (_, idx) in deserializedCards.Select((x, idx) => (x, idx))


### PR DESCRIPTION
# Description

This PR fixes an empty inventory bug after running server with `"from_json": true`.

# How to reproduce
1. Put `cdb` file in `Cache` directory
2. In `Configs/configs.json` set
```
  "to_json": true,
  "to_json_name": "catalogue_dump.json",
  "from_json": false,
  "from_json_name": "catalogue_dump.json",
```
3. Start and stop the server - this will deserialize `cdb` file to `catalogue_dump.json`
4. In `Configs/configs.json` set
```
  "to_json": false,
  "to_json_name": "catalogue_dump.json",
  "from_json": true,
  "from_json_name": "catalogue_dump.json",
```
5. Start the server - this will serialize `catalogue_dump.json` into the new `cdb` file, overwriting the latter.
6. Open the game and connect to the server.

In `nascarman9/bnlReloaded` the inventory item are gone (heroes, perks, skins etc.).
In `bayergg/bnlReloaded` the inventory persists.