### PR TITLE
Added player counts to region names

### DIFF
--- a/BNLReloadedServer/Database/IMasterServerDatabase.cs
+++ b/BNLReloadedServer/Database/IMasterServerDatabase.cs
@@ -9,6 +9,8 @@ public interface IMasterServerDatabase
     public List<RegionInfo> GetRegionServers();
     public bool AddRegionServer(string id, string host, RegionGuiInfo regionGuiInfo, IServiceMasterServer? serviceMasterServer = null);
     public bool RemoveRegionServer(string id);
+    public bool UpdateRegionPlayerCount(string id, int playerCount);
+    public int GetRegionPlayerCount(string id);
     public RegionInfo? GetRegionServer(string id);
     public Task<PlayerData> AddPlayer(ulong steamId, string playerName, string region);
     public Task<PlayerData?> GetPlayer(ulong steamId);

--- a/BNLReloadedServer/Database/IMasterServerDatabase.cs
+++ b/BNLReloadedServer/Database/IMasterServerDatabase.cs
@@ -9,7 +9,7 @@ public interface IMasterServerDatabase
     public List<RegionInfo> GetRegionServers();
     public bool AddRegionServer(string id, string host, RegionGuiInfo regionGuiInfo, IServiceMasterServer? serviceMasterServer = null);
     public bool RemoveRegionServer(string id);
-    public bool UpdateRegionPlayerCount(string id, int playerCount);
+    public bool SetRegionPlayerCount(string id, int playerCount);
     public int GetRegionPlayerCount(string id);
     public RegionInfo? GetRegionServer(string id);
     public Task<PlayerData> AddPlayer(ulong steamId, string playerName, string region);

--- a/BNLReloadedServer/Database/MasterServerDatabase.cs
+++ b/BNLReloadedServer/Database/MasterServerDatabase.cs
@@ -52,17 +52,27 @@ public class MasterServerDatabase : IMasterServerDatabase
         return false;
     }
 
-    public bool UpdateRegionPlayerCount(string id, int playerCount)
+    public bool SetRegionPlayerCount(string id, int playerCount)
     {
-        if (_regionServers.All(r => r.Id != id)) return false;
+        if (GetRegionServer(id) == null)
+        {
+            // No region with such id found,
+            // If special "master" region exists threat it as master change, else fail
+            if (GetRegionServer("master") == null)
+            {
+                return false;
+            }
+            else
+            {
+                _regionPlayerCounts["master"] = playerCount;
+                return true;
+            }
+        }
         _regionPlayerCounts[id] = playerCount;
         return true;
     }
 
-    public int GetRegionPlayerCount(string id)
-    {
-        return _regionPlayerCounts.GetValueOrDefault(id, 0);
-    }
+    public int GetRegionPlayerCount(string id) => _regionPlayerCounts.GetValueOrDefault(id, 0);
 
     public RegionInfo? GetRegionServer(string id) => _regionServers.FirstOrDefault(x => x.Id == id);
 

--- a/BNLReloadedServer/Database/MasterServerDatabase.cs
+++ b/BNLReloadedServer/Database/MasterServerDatabase.cs
@@ -11,6 +11,7 @@ public class MasterServerDatabase : IMasterServerDatabase
 {
     private readonly List<RegionInfo> _regionServers = [];
     private readonly ConcurrentDictionary<string, IServiceMasterServer> _regionServerConnections = new();
+    private readonly ConcurrentDictionary<string, int> _regionPlayerCounts = new();
     private readonly SQLiteAsyncConnection _playerDb;
     
     private readonly SemaphoreSlim _asyncLock = new(1, 1);
@@ -42,12 +43,25 @@ public class MasterServerDatabase : IMasterServerDatabase
 
     public bool RemoveRegionServer(string id)
     {
+        _regionPlayerCounts.TryRemove(id, out _);
         if (_regionServerConnections.Remove(id, out _))
         {
             return _regionServers.RemoveAll(r => r.Id == id) > 0;
         }
         
         return false;
+    }
+
+    public bool UpdateRegionPlayerCount(string id, int playerCount)
+    {
+        if (_regionServers.All(r => r.Id != id)) return false;
+        _regionPlayerCounts[id] = playerCount;
+        return true;
+    }
+
+    public int GetRegionPlayerCount(string id)
+    {
+        return _regionPlayerCounts.GetValueOrDefault(id, 0);
     }
 
     public RegionInfo? GetRegionServer(string id) => _regionServers.FirstOrDefault(x => x.Id == id);

--- a/BNLReloadedServer/Database/PlayerDatabase.cs
+++ b/BNLReloadedServer/Database/PlayerDatabase.cs
@@ -100,13 +100,17 @@ public class PlayerDatabase : IPlayerDatabase
             task.SetResult(player);
         }
 
+        _serviceRegionServer?.SendPlayerCount(_players.Count);
         return true;
     }
 
     public bool RemovePlayer(uint playerId)
     {
         _steamFriends.Remove(playerId, out _);
-        return _players.Remove(playerId, out _);
+        var removed = _players.Remove(playerId, out _);
+        if (removed)
+            _serviceRegionServer?.SendPlayerCount(_players.Count);
+        return removed;
     }
 
     public uint? GetPlayerId(ulong steamId) => _players.Values.FirstOrDefault(p => p.SteamId == steamId)?.PlayerId;
@@ -191,6 +195,7 @@ public class PlayerDatabase : IPlayerDatabase
     public void SetRegionServerService(IServiceRegionServer serviceRegionServer)
     {
         _serviceRegionServer = serviceRegionServer;
+        _serviceRegionServer.SendPlayerCount(_players.Count);
     }
 
     public string GetPlayerName(uint playerId) => _players.GetValueOrDefault(playerId)?.Nickname ?? string.Empty;

--- a/BNLReloadedServer/Servers/RegionClient.cs
+++ b/BNLReloadedServer/Servers/RegionClient.cs
@@ -10,7 +10,7 @@ public class RegionClient : TcpClient
     private readonly SessionReader _reader;
     private bool _connected;
 
-    public RegionClient(string address, int port) : base(address, port)
+    public RegionClient(string address, int port) : base(address == "0.0.0.0" ? "127.0.0.1" : address, port)
     {
         var sender = new ClientSender(this);
         _serviceDispatcher = new RegionClientServiceDispatcher(sender);
@@ -67,7 +67,7 @@ public class RegionClient : TcpClient
 
     protected override void OnError(SocketError error)
     {
-        Console.WriteLine($"Chat TCP client caught an error with code {error}");
+        Console.WriteLine($"Region TCP client caught an error with code {error}");
     }
 
     private bool _stop;

--- a/BNLReloadedServer/Servers/RegionClient.cs
+++ b/BNLReloadedServer/Servers/RegionClient.cs
@@ -10,7 +10,7 @@ public class RegionClient : TcpClient
     private readonly SessionReader _reader;
     private bool _connected;
 
-    public RegionClient(string address, int port) : base(address == "0.0.0.0" ? "127.0.0.1" : address, port)
+    public RegionClient(string address, int port) : base(address, port)
     {
         var sender = new ClientSender(this);
         _serviceDispatcher = new RegionClientServiceDispatcher(sender);

--- a/BNLReloadedServer/Service/IServiceRegionServer.cs
+++ b/BNLReloadedServer/Service/IServiceRegionServer.cs
@@ -20,4 +20,5 @@ public interface IServiceRegionServer : IService
     public Task<List<SearchResult>?> SendFriendSearchRequest(List<uint> players);
     public Task<List<SearchResult>?> SendFriendSearchSteamRequest(List<ulong> players);
     public Task<List<LeagueLeaderboardRecord>?> SendLeagueLeaderboardRequest();
+    public void SendPlayerCount(int playerCount);
 }

--- a/BNLReloadedServer/Service/ServiceLogin.cs
+++ b/BNLReloadedServer/Service/ServiceLogin.cs
@@ -238,16 +238,23 @@ public class ServiceLogin(ISender sender, Guid sessionId) : IServiceLogin
             writer.Write(error ?? string.Empty);
         }
         sender.Send(writer);
-        
-        var regionServers = _masterServerDatabase.GetRegionServers();
-        foreach (var region in regionServers)
+
+        var regionServers = _masterServerDatabase.GetRegionServers().Select(region => new RegionInfo
         {
-            if (region is { Info.Name: { } name })
+            Id = region.Id,
+            Host = region.Host,
+            Port = region.Port,
+            Info = region.Info == null ? null : new RegionGuiInfo
             {
-                name.Text += $"\n{_masterServerDatabase.GetRegionPlayerCount(region.Id ?? string.Empty)} online";
+                Icon = region.Info.Icon,
+                Name = region.Info.Name == null ? null : new LocalizedString
+                {
+                    Text = (region.Info.Name.Text ?? string.Empty) + $"\n{_masterServerDatabase.GetRegionPlayerCount(region.Id ?? string.Empty)} online",
+                    Data = region.Info.Name.Data
+                }
             }
-        }
-        
+        }).ToList();
+
         if (regionServers.Count == 1 && sender.AssociatedPlayerId.HasValue)
         {
             EnterRegion(sender.AssociatedPlayerId.Value, regionServers.Single());

--- a/BNLReloadedServer/Service/ServiceLogin.cs
+++ b/BNLReloadedServer/Service/ServiceLogin.cs
@@ -240,6 +240,14 @@ public class ServiceLogin(ISender sender, Guid sessionId) : IServiceLogin
         sender.Send(writer);
         
         var regionServers = _masterServerDatabase.GetRegionServers();
+        foreach (var region in regionServers)
+        {
+            if (region is { Info.Name: { } name })
+            {
+                name.Text += $"\n{_masterServerDatabase.GetRegionPlayerCount(region.Id ?? string.Empty)} online";
+            }
+        }
+        
         if (regionServers.Count == 1 && sender.AssociatedPlayerId.HasValue)
         {
             EnterRegion(sender.AssociatedPlayerId.Value, regionServers.Single());

--- a/BNLReloadedServer/Service/ServiceMasterServer.cs
+++ b/BNLReloadedServer/Service/ServiceMasterServer.cs
@@ -36,7 +36,8 @@ public class ServiceMasterServer(ISender sender, Guid sessionId) : IServiceMaste
     }
     
     private readonly IMasterServerDatabase _masterServerDatabase = Databases.MasterServerDatabase;
-    
+    private string? _regionId;
+
     private static BinaryWriter CreateWriter()
     {
         var memStream = new MemoryStream();
@@ -181,20 +182,21 @@ public class ServiceMasterServer(ISender sender, Guid sessionId) : IServiceMaste
         var regionInfo = RegionGuiInfo.ReadRecord(reader);
         if (host == Databases.ConfigDatabase.MasterPublicHost())
         {
-            _masterServerDatabase.AddRegionServer("master", host, regionInfo, this);
+            _regionId = "master";
         }
         else
         {
-            _masterServerDatabase.AddRegionServer(sessionId.ToString(), host, regionInfo, this);
+            _regionId = sessionId.ToString();
             SendMasterCdb(CatalogueCache.Load());
             foreach (var map in Databases.MapDatabase.GetMapCards())
             {
                 if (map.Id is null || Databases.MapDatabase.LoadMapData(Catalogue.Key(map.Id)) is not {} mapData)
                     continue;
-            
+
                 SendMap(map.Id, map, mapData);
             }
         }
+        _masterServerDatabase.AddRegionServer(_regionId, host, regionInfo, this);
         SendPublicKey(Databases.PlayerDatabase.GetPublicKey());
     }
     
@@ -316,13 +318,9 @@ public class ServiceMasterServer(ISender sender, Guid sessionId) : IServiceMaste
     public void ReceivePlayerCount(BinaryReader reader)
     {
         var playerCount = reader.ReadInt32();
-        if (sessionId == Guid.Empty)
+        if (_regionId != null)
         {
-            _masterServerDatabase.UpdateRegionPlayerCount("master", playerCount);
-        }
-        else
-        {
-            _masterServerDatabase.UpdateRegionPlayerCount(sessionId.ToString(), playerCount);
+            _masterServerDatabase.UpdateRegionPlayerCount(_regionId, playerCount);
         }
     }
 

--- a/BNLReloadedServer/Service/ServiceMasterServer.cs
+++ b/BNLReloadedServer/Service/ServiceMasterServer.cs
@@ -36,7 +36,6 @@ public class ServiceMasterServer(ISender sender, Guid sessionId) : IServiceMaste
     }
     
     private readonly IMasterServerDatabase _masterServerDatabase = Databases.MasterServerDatabase;
-    private string? _regionId;
 
     private static BinaryWriter CreateWriter()
     {
@@ -182,11 +181,11 @@ public class ServiceMasterServer(ISender sender, Guid sessionId) : IServiceMaste
         var regionInfo = RegionGuiInfo.ReadRecord(reader);
         if (host == Databases.ConfigDatabase.MasterPublicHost())
         {
-            _regionId = "master";
+            _masterServerDatabase.AddRegionServer("master", host, regionInfo, this);
         }
         else
         {
-            _regionId = sessionId.ToString();
+            _masterServerDatabase.AddRegionServer(sessionId.ToString(), host, regionInfo, this);
             SendMasterCdb(CatalogueCache.Load());
             foreach (var map in Databases.MapDatabase.GetMapCards())
             {
@@ -196,7 +195,6 @@ public class ServiceMasterServer(ISender sender, Guid sessionId) : IServiceMaste
                 SendMap(map.Id, map, mapData);
             }
         }
-        _masterServerDatabase.AddRegionServer(_regionId, host, regionInfo, this);
         SendPublicKey(Databases.PlayerDatabase.GetPublicKey());
     }
     
@@ -318,10 +316,7 @@ public class ServiceMasterServer(ISender sender, Guid sessionId) : IServiceMaste
     public void ReceivePlayerCount(BinaryReader reader)
     {
         var playerCount = reader.ReadInt32();
-        if (_regionId != null)
-        {
-            _masterServerDatabase.UpdateRegionPlayerCount(_regionId, playerCount);
-        }
+        _masterServerDatabase.SetRegionPlayerCount(sessionId.ToString(), playerCount);
     }
 
     public bool Receive(BinaryReader reader)

--- a/BNLReloadedServer/Service/ServiceMasterServer.cs
+++ b/BNLReloadedServer/Service/ServiceMasterServer.cs
@@ -31,7 +31,8 @@ public class ServiceMasterServer(ISender sender, Guid sessionId) : IServiceMaste
         MessageFriendRequest = 18,
         MessageFriendSearch = 19,
         MessageFriendSearchSteam = 20,
-        MessageGetLeaderboard = 21
+        MessageGetLeaderboard = 21,
+        MessagePlayerCount = 22
     }
     
     private readonly IMasterServerDatabase _masterServerDatabase = Databases.MasterServerDatabase;
@@ -312,6 +313,18 @@ public class ServiceMasterServer(ISender sender, Guid sessionId) : IServiceMaste
         
         SendLeaderboard(rpcId, _masterServerDatabase.GetLeaderboard().Result);
     }
+    public void ReceivePlayerCount(BinaryReader reader)
+    {
+        var playerCount = reader.ReadInt32();
+        if (sessionId == Guid.Empty)
+        {
+            _masterServerDatabase.UpdateRegionPlayerCount("master", playerCount);
+        }
+        else
+        {
+            _masterServerDatabase.UpdateRegionPlayerCount(sessionId.ToString(), playerCount);
+        }
+    }
 
     public bool Receive(BinaryReader reader)
     {
@@ -376,6 +389,9 @@ public class ServiceMasterServer(ISender sender, Guid sessionId) : IServiceMaste
                 break;
             case ServiceMasterId.MessageGetLeaderboard:
                 ReceiveLeaderboard(reader);
+                break;
+            case ServiceMasterId.MessagePlayerCount:
+                ReceivePlayerCount(reader);
                 break;
             default:
                 Console.WriteLine($"Master service received unsupported serviceId: {serviceMasterId}");

--- a/BNLReloadedServer/Service/ServiceRegionServer.cs
+++ b/BNLReloadedServer/Service/ServiceRegionServer.cs
@@ -347,14 +347,6 @@ public class ServiceRegionServer(ISender sender) : IServiceRegionServer
         return await tcs.Task as List<LeagueLeaderboardRecord>;
     }
 
-    public void SendPlayerCount(int playerCount)
-    {
-        using var writer = CreateWriter();
-        writer.Write((byte)ServiceRegionId.MessagePlayerCount);
-        writer.Write(playerCount);
-        sender.Send(writer);
-    }
-    
     public void ReceiveLeaderboard(BinaryReader reader)
     {
         var rpcId = reader.ReadUInt16();
@@ -365,6 +357,14 @@ public class ServiceRegionServer(ISender sender) : IServiceRegionServer
         {
             tcs.SetResult(results);
         }
+    }
+
+    public void SendPlayerCount(int playerCount)
+    {
+        using var writer = CreateWriter();
+        writer.Write((byte)ServiceRegionId.MessagePlayerCount);
+        writer.Write(playerCount);
+        sender.Send(writer);
     }
 
     public bool Receive(BinaryReader reader)

--- a/BNLReloadedServer/Service/ServiceRegionServer.cs
+++ b/BNLReloadedServer/Service/ServiceRegionServer.cs
@@ -32,7 +32,8 @@ public class ServiceRegionServer(ISender sender) : IServiceRegionServer
         MessageFriendRequest = 18,
         MessageFriendSearch = 19,
         MessageFriendSearchSteam = 20,
-        MessageGetLeaderboard = 21
+        MessageGetLeaderboard = 21,
+        MessagePlayerCount = 22
     }
 
     private ushort _currRpcId = 1;
@@ -344,6 +345,14 @@ public class ServiceRegionServer(ISender sender) : IServiceRegionServer
         
         sender.Send(writer);
         return await tcs.Task as List<LeagueLeaderboardRecord>;
+    }
+
+    public void SendPlayerCount(int playerCount)
+    {
+        using var writer = CreateWriter();
+        writer.Write((byte)ServiceRegionId.MessagePlayerCount);
+        writer.Write(playerCount);
+        sender.Send(writer);
     }
     
     public void ReceiveLeaderboard(BinaryReader reader)


### PR DESCRIPTION
<img width="2560" height="1080" alt="image" src="https://github.com/user-attachments/assets/77faa625-8305-40b0-a835-4ad3302cb2f3" />

In short, I added one message type in region-server communications, so when a player joins or leaves region, region sends updated player count to master. Master server then saves this value to it's runtime database. Traffic usage is minimal, messages are event based.

Also added minor fixes to allow region and master servers be run in same application with 0.0.0.0 wildcard address.